### PR TITLE
fixed null references for sprites

### DIFF
--- a/LoZGame/Enemies/EnemyClasses/Stalfos.cs
+++ b/LoZGame/Enemies/EnemyClasses/Stalfos.cs
@@ -99,10 +99,9 @@
         public void Update()
         {
             this.lifeTime++;
-            //this.UpdateLoc();
+            this.UpdateLoc();
             if (this.lifeTime > this.directionChange)
             {
-               // this.GetNewDirection();
                 randomStateGenerator.Update();
                 this.lifeTime = 0;
             }

--- a/LoZGame/Enemies/EnemyStates/StalfosStates/LeftMovingStalfosState.cs
+++ b/LoZGame/Enemies/EnemyStates/StalfosStates/LeftMovingStalfosState.cs
@@ -6,7 +6,7 @@
     public class LeftMovingStalfosState : IEnemyState
     {
         private readonly Stalfos stalfos;
-        private readonly IEnemySprite sprite;
+        private IEnemySprite sprite;
 
         public LeftMovingStalfosState(Stalfos stalfos)
         {
@@ -19,6 +19,7 @@
 
         public void MoveLeft()
         {
+            this.stalfos.CurrentState = new LeftMovingStalfosState(this.stalfos);
         }
 
         public void MoveRight()

--- a/LoZGame/LoZGame.cs
+++ b/LoZGame/LoZGame.cs
@@ -38,7 +38,7 @@
 
         public static LoZGame Instance { get { return instance; } }
 
-        public ItemManager Items { get { return itemManager; }  }
+        public ItemManager Items { get { return itemManager; } }
 
         public BlockManager Blocks { get { return blockManager; } }
 
@@ -61,36 +61,41 @@
 
         protected override void Initialize()
         {
-            BlockSpriteFactory.Instance.LoadAllTextures(this.Content); //needs to change
-            string file = "../../../../../etc/levels/dungeon1.xml";
-            this.link = new Link();
-            this.dungeon = new Dungeon(file);
-            this.keyboardCommandLoader = new KeyboardCommandLoader(this.link, this.dungeon);
-            this.mouseCommandLoader = new MouseCommandLoader(this.dungeon);
-
             this.controllers = new List<IController>();
-            this.controllers.Add(new KeyboardController(this.keyboardCommandLoader));
-            this.controllers.Add(new MouseController(this.mouseCommandLoader));
-
             this.players = new List<IPlayer>();
-            this.players.Add(this.link);
-
             this.projectiles = new List<IProjectile>();
-
             base.Initialize();
         }
 
         protected override void LoadContent()
         {
-            this.spriteBatch = new SpriteBatch(this.GraphicsDevice);
             LinkSpriteFactory.Instance.LoadAllTextures(this.Content);
-            ItemSpriteFactory.Instance.LoadAllTextures(this.Content);
+            this.link = new Link();
 
+            ItemSpriteFactory.Instance.LoadAllTextures(this.Content);
             ProjectileSpriteFactory.Instance.LoadAllTextures(this.Content);
             EnemySpriteFactory.Instance.LoadAllTextures(this.Content);
+            BlockSpriteFactory.Instance.LoadAllTextures(this.Content);
+
+            string file = "../../../../../etc/levels/dungeon1.xml";
+            this.dungeon = new Dungeon(file);
+
+
+            this.keyboardCommandLoader = new KeyboardCommandLoader(this.link, this.dungeon);
+            this.mouseCommandLoader = new MouseCommandLoader(this.dungeon);
+
+
+            this.controllers.Add(new KeyboardController(this.keyboardCommandLoader));
+            this.controllers.Add(new MouseController(this.mouseCommandLoader));
+
+
+            this.players.Add(this.link);
+
+
+            this.spriteBatch = new SpriteBatch(this.GraphicsDevice);
+
+
             this.itemManager.LoadSprites(384, 184);
-
-
         }
 
         protected override void UnloadContent()

--- a/LoZGame/obj/x86/Debug/LoZGame.csproj.FileListAbsolute.txt
+++ b/LoZGame/obj/x86/Debug/LoZGame.csproj.FileListAbsolute.txt
@@ -986,3 +986,15 @@ C:\Users\wensi\Desktop\3902proj\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\un
 C:\Users\wensi\Desktop\3902proj\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_left.xnb
 C:\Users\wensi\Desktop\3902proj\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_right.xnb
 C:\Users\wensi\Desktop\3902proj\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_up.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\locked_door_down.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\locked_door_left.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\locked_door_right.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\locked_door_up.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\special_door_down.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\special_door_left.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\special_door_right.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\special_door_up.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_down.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_left.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_right.xnb
+C:\Users\16reh\Desktop\LoZGame\LoZGame\bin\Windows\x86\Debug\Content\unlocked_door_up.xnb


### PR DESCRIPTION
Fixed null references due to load order in main LoadContent and Initialize methods. Link should theoretically also no longer need a Null State